### PR TITLE
Tweak gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,12 +55,6 @@ cover/
 *.mo
 *.pot
 
-# Django stuff:
-*.log
-local_settings.py
-db.sqlite3
-db.sqlite3-journal
-
 # Flask stuff:
 instance/
 .webassets-cache


### PR DESCRIPTION
Make a harmless change to gitignore.
This is meant to test the "skip release if nothing changed" logic in the release workflow.