### PR TITLE
Use own copy of wheeldiff rather than installed

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,7 +37,7 @@ jobs:
       - name: Prepare for wheel check
         run: |
           pip download --no-deps --only-binary :all: --implementation py --platform none wheeldiff
-          pip install wheeldiff
+          pip install .
 
       - name: Check if wheel content changed
         id: wheeldiff


### PR DESCRIPTION
In case the last version on PyPI has a bug.