### PR TITLE
renovate: try disabling non-lockfile updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -5,12 +5,22 @@
   ],
   "pip-compile": {
     "enabled": true,
-    "fileMatch": ["requirements[^/]*\\.txt$"]
+    "fileMatch": [
+      "requirements[^/]*\\.txt$"
+    ],
+    "packageRules": [
+      {
+        "matchPackageNames": [
+          ".*"
+        ],
+        "allowedVersions": "!/.*/"
+      }
+    ]
   },
   "lockFileMaintenance": {
     "enabled": true,
     "schedule": [
-      "before 4am on monday"
+      "at any time"
     ]
   }
 }


### PR DESCRIPTION
The intent here is to have python deps managed *only* by doing scheduled pip-compiles (while letting other default managers, e.g. github actions, continue to work as normal).