### PR TITLE
renovate: more tweaks for python

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -3,18 +3,13 @@
   "extends": [
     "config:recommended"
   ],
+  "pip_requirements": {
+    "enabled": false
+  },
   "pip-compile": {
     "enabled": true,
     "fileMatch": [
       "requirements[^/]*\\.txt$"
-    ],
-    "packageRules": [
-      {
-        "matchPackageNames": [
-          ".*"
-        ],
-        "allowedVersions": "!/.*/"
-      }
     ]
   },
   "lockFileMaintenance": {


### PR DESCRIPTION
Judging from the dashboard, "pip_requirements" is the manager I want disabled, while "pip-compile" should be used for lockfile maintenance.