### PR TITLE
renovate: disable duplicate(?) lockfile management

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -11,11 +11,5 @@
     "fileMatch": [
       "requirements[^/]*\\.txt$"
     ]
-  },
-  "lockFileMaintenance": {
-    "enabled": true,
-    "schedule": [
-      "at any time"
-    ]
   }
 }


### PR DESCRIPTION
Judging from the dashboard, pip-compile's lockFileMaintenance defaults to enabled, and this with the top-level lockFileMaintenance shouldn't both be enabled.